### PR TITLE
Use `concurrency` to cancel jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,9 @@ on:
 jobs:
   ubuntu:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: true
     env:
       GOOGLE_SHEET_SPOT_URL: ${{ secrets.GOOGLE_SHEET_SPOT_URL }}
       GOOGLE_SHEET_BASIC_URL: ${{ secrets.GOOGLE_SHEET_BASIC_URL }}


### PR DESCRIPTION
It is mainly used to cancel jobs that are started by user envet on UI.

ie. AppSheet automation.
